### PR TITLE
Fix session notifications to show title/summary instead of raw query

### DIFF
--- a/humanlayer-wui/src/components/Layout.tsx
+++ b/humanlayer-wui/src/components/Layout.tsx
@@ -21,7 +21,7 @@ import { useSessionSubscriptions } from '@/hooks/useSubscriptions'
 import { Toaster } from 'sonner'
 import { notificationService, type NotificationOptions } from '@/services/NotificationService'
 import { useTheme } from '@/contexts/ThemeContext'
-import { formatMcpToolName } from '@/utils/formatting'
+import { formatMcpToolName, getSessionNotificationText } from '@/utils/formatting'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { MessageCircle, Bug } from 'lucide-react'
 import { openUrl } from '@tauri-apps/plugin-opener'
@@ -102,10 +102,12 @@ export function Layout() {
         }
 
         try {
+          const sessionText = getSessionNotificationText(session)
+          
           let notificationOptions: NotificationOptions = {
             type: 'session_completed',
             title: `Session Completed (${data.session_id.slice(0, 8)})`,
-            body: `Completed: ${session.query}`,
+            body: `Completed: ${sessionText}`,
             metadata: {
               sessionId: data.session_id,
               model: session.model,
@@ -117,7 +119,7 @@ export function Layout() {
           if (nextStatus === SessionStatus.Failed) {
             notificationOptions.type = 'session_failed'
             notificationOptions.title = `Session Failed (${data.session_id.slice(0, 8)})`
-            notificationOptions.body = session.errorMessage || `Failed: ${session.query}`
+            notificationOptions.body = session.errorMessage || `Failed: ${sessionText}`
             notificationOptions.priority = 'high'
           }
 

--- a/humanlayer-wui/src/utils/formatting.test.ts
+++ b/humanlayer-wui/src/utils/formatting.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from 'bun:test'
+import { getSessionNotificationText } from './formatting'
+
+describe('getSessionNotificationText', () => {
+  test('returns title when available', () => {
+    const session = {
+      title: 'My Session Title',
+      summary: 'My Session Summary',
+      query: 'My raw query text',
+    }
+    expect(getSessionNotificationText(session)).toBe('My Session Title')
+  })
+
+  test('returns summary when title is not available', () => {
+    const session = {
+      summary: 'My Session Summary',
+      query: 'My raw query text',
+    }
+    expect(getSessionNotificationText(session)).toBe('My Session Summary')
+  })
+
+  test('returns query when neither title nor summary is available', () => {
+    const session = {
+      query: 'My raw query text',
+    }
+    expect(getSessionNotificationText(session)).toBe('My raw query text')
+  })
+
+  test('truncates text to default 40 characters', () => {
+    const session = {
+      title: 'This is a very long title that should be truncated to exactly 40 characters for display',
+      query: 'short query',
+    }
+    expect(getSessionNotificationText(session)).toBe('This is a very long title that should be')
+    expect(getSessionNotificationText(session).length).toBe(40)
+  })
+
+  test('truncates text to custom maxLength', () => {
+    const session = {
+      title: 'This is a title that will be truncated',
+      query: 'short query',
+    }
+    expect(getSessionNotificationText(session, 10)).toBe('This is a ')
+    expect(getSessionNotificationText(session, 10).length).toBe(10)
+  })
+
+  test('handles empty title and summary', () => {
+    const session = {
+      title: '',
+      summary: '',
+      query: 'Fallback to query text',
+    }
+    expect(getSessionNotificationText(session)).toBe('Fallback to query text')
+  })
+
+  test('handles undefined title and summary', () => {
+    const session = {
+      title: undefined,
+      summary: undefined,
+      query: 'Fallback to query text',
+    }
+    expect(getSessionNotificationText(session)).toBe('Fallback to query text')
+  })
+
+  test('preserves short text without truncation', () => {
+    const session = {
+      title: 'Short title',
+      query: 'query',
+    }
+    expect(getSessionNotificationText(session)).toBe('Short title')
+  })
+
+  test('handles exactly 40 character text', () => {
+    const session = {
+      title: '1234567890123456789012345678901234567890', // Exactly 40 chars
+      query: 'query',
+    }
+    expect(getSessionNotificationText(session)).toBe('1234567890123456789012345678901234567890')
+    expect(getSessionNotificationText(session).length).toBe(40)
+  })
+
+  test('handles text with special characters', () => {
+    const session = {
+      title: '🚀 Deploy to production! 💻 #urgent-fix',
+      query: 'query',
+    }
+    expect(getSessionNotificationText(session)).toBe('🚀 Deploy to production! 💻 #urgent-fix')
+  })
+
+  test('handles text with newlines and tabs', () => {
+    const session = {
+      title: 'Title with\nnewline and\ttabs',
+      query: 'query',
+    }
+    expect(getSessionNotificationText(session)).toBe('Title with\nnewline and\ttabs')
+  })
+
+  test('prioritizes title over summary and query', () => {
+    const session = {
+      title: 'Title',
+      summary: 'Summary should not be used',
+      query: 'Query should not be used',
+    }
+    expect(getSessionNotificationText(session)).toBe('Title')
+  })
+
+  test('prioritizes summary over query when no title', () => {
+    const session = {
+      title: '',
+      summary: 'Summary',
+      query: 'Query should not be used',
+    }
+    expect(getSessionNotificationText(session)).toBe('Summary')
+  })
+})

--- a/humanlayer-wui/src/utils/formatting.ts
+++ b/humanlayer-wui/src/utils/formatting.ts
@@ -137,3 +137,18 @@ export function formatMcpToolName(toolName: string): string {
   const { service, method } = parseMcpToolName(toolName)
   return `${service} - ${method.replace(/_/g, ' ')}`
 }
+
+/**
+ * Get formatted session text for notifications
+ * Prioritizes human-readable title/summary over raw query and truncates to maxLength
+ * @param session - Session object with optional title, summary, and query fields
+ * @param maxLength - Maximum length of the returned text (default: 40)
+ * @returns Formatted session text truncated to maxLength
+ */
+export function getSessionNotificationText(
+  session: { title?: string; summary?: string; query: string },
+  maxLength: number = 40
+): string {
+  const text = session.title || session.summary || session.query
+  return text.slice(0, maxLength)
+}


### PR DESCRIPTION
# Fix session notifications to show title/summary instead of raw query

## Summary
This PR fixes a bug where session completion and failure notifications were displaying raw query text instead of the human-readable title or summary. The notifications now follow the same display pattern used throughout the rest of the UI, providing a better user experience.

## Problem
Session notifications (both completion and failure) were showing the raw query text in the notification body, which could be:
- Technical and hard to understand
- Very long and unwieldy
- Inconsistent with how sessions are displayed elsewhere in the UI

For example, a notification might show:
> Completed: find all instances of getCwd in the codebase and rename them to getCurrentWorkingDirectory across all files ensuring consistency

Instead of the cleaner summary:
> Completed: Rename getCwd to getCurrentWorkingDirectory

## Solution
1. **Created a reusable helper function** `getSessionNotificationText()` that:
   - Implements the standard fallback pattern: title → summary → query
   - Truncates text to 40 characters to prevent overly long notifications
   - Provides TypeScript type safety

2. **Refactored the notification logic** in `Layout.tsx` to use the helper function instead of inline logic

3. **Added comprehensive unit tests** (13 test cases) covering:
   - Priority logic (title preferred over summary, summary over query)
   - Text truncation with default and custom lengths
   - Edge cases (empty strings, undefined values, special characters)
   - All tests are passing ✅

## Changes Made
- **`humanlayer-wui/src/utils/formatting.ts`**: Added `getSessionNotificationText()` helper function
- **`humanlayer-wui/src/utils/formatting.test.ts`**: Created comprehensive unit tests (new file)
- **`humanlayer-wui/src/components/Layout.tsx`**: Updated to use the helper function

## User Impact
- ✅ Users will see cleaner, more readable notification text
- ✅ Notifications are now consistent with the rest of the UI
- ✅ Long text is properly truncated to avoid overwhelming notifications
- ✅ No breaking changes - this is a pure improvement

## Testing
### Automated Tests
- [x] Unit tests pass: `cd humanlayer-wui && bun test src/utils/formatting.test.ts`
- [x] TypeScript compilation: `cd humanlayer-wui && npm run typecheck`

### Manual Testing Required
- [ ] Launch a Claude Code session and verify completion notification shows the summary
- [ ] Cancel a session and verify failure notification shows the summary
- [ ] Test with a session that has no title/summary to verify fallback to query works

## Screenshots/Examples
### Before
```
Notification: "Completed: find all instances of getCwd in the codebase and..."
```

### After  
```
Notification: "Completed: Rename getCwd to getCurrentWorking"
```
(Text truncated at 40 characters)

## Migration Notes
None - this is a bug fix with no breaking changes.

## Checklist
- [x] Code follows the existing patterns in the codebase
- [x] Tests have been added/updated
- [x] TypeScript types are properly defined
- [x] The change is focused and doesn't include unrelated modifications
- [ ] Manual testing completed (needs UI verification)

## Related Issues
- Fixes ENG-1810: Session completed notifications show summary/last user message instead of session.query

## Additional Notes
The 40-character limit for notification text was chosen to balance informativeness with brevity. This can be easily adjusted if needed by modifying the default parameter in the `getSessionNotificationText` function.